### PR TITLE
[EC-290] Post and get from the SightUp api the user's test results

### DIFF
--- a/composeApp/src/commonMain/composeResources/drawable/eight_e_down.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/eight_e_down.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="3dp"
+    android:height="3dp"
+    android:viewportWidth="3"
+    android:viewportHeight="3">
+  <group>
+    <clip-path
+        android:pathData="M0,0h3v3h-3z"/>
+    <path
+        android:pathData="M1.1995,0.6V3H1.7995V0.6H2.3995V3H2.9995V0.6V0H2.3995H1.7995H1.1995H0.5995H-0.0005V0.6V3H0.5995V0.6H1.1995Z"
+        android:fillColor="#000000"/>
+  </group>
+</vector>

--- a/composeApp/src/commonMain/composeResources/drawable/eight_e_left.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/eight_e_left.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="4dp"
+    android:height="3dp"
+    android:viewportWidth="4"
+    android:viewportHeight="3">
+  <group>
+    <clip-path
+        android:pathData="M0.3335,0h3v3h-3z"/>
+    <path
+        android:pathData="M2.7335,1.8H0.3335V1.2H2.7335V0.6H0.3335V0H2.7335H3.3335V0.6V1.2V1.8V2.4V3H2.7335H0.3335V2.4H2.7335V1.8Z"
+        android:fillColor="#000000"/>
+  </group>
+</vector>

--- a/composeApp/src/commonMain/composeResources/drawable/eight_e_right.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/eight_e_right.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="3dp"
+    android:height="3dp"
+    android:viewportWidth="3"
+    android:viewportHeight="3">
+  <group>
+    <clip-path
+        android:pathData="M0,0h3v3h-3z"/>
+    <path
+        android:pathData="M0.5995,1.8H2.9995V1.2H0.5995V0.6H2.9995V0H0.5995H-0.0005V0.6V1.2V1.8V2.4V3H0.5995H2.9995V2.4H0.5995V1.8Z"
+        android:fillColor="#000000"/>
+  </group>
+</vector>

--- a/composeApp/src/commonMain/composeResources/drawable/eight_e_up.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/eight_e_up.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="4dp"
+    android:height="3dp"
+    android:viewportWidth="4"
+    android:viewportHeight="3">
+  <group>
+    <clip-path
+        android:pathData="M0.5117,0h3v3h-3z"/>
+    <path
+        android:pathData="M1.7122,2.4V0H2.3122V2.4H2.9122V0H3.5122V2.4V3H2.9122H2.3122H1.7122H1.1122H0.5122V2.4V0H1.1122V2.4H1.7122Z"
+        android:fillColor="#000000"/>
+  </group>
+</vector>

--- a/composeApp/src/commonMain/composeResources/drawable/five_e_down.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/five_e_down.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="9dp"
+    android:height="9dp"
+    android:viewportWidth="9"
+    android:viewportHeight="9">
+  <group>
+    <clip-path
+        android:pathData="M0,0h9v9h-9z"/>
+    <path
+        android:pathData="M3.6,1.8V9H5.4V1.8H7.2V9H9V1.8V0H7.2H5.4H3.6H1.8H0V1.8V9H1.8V1.8H3.6Z"
+        android:fillColor="#000000"/>
+  </group>
+</vector>

--- a/composeApp/src/commonMain/composeResources/drawable/five_e_left.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/five_e_left.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="9dp"
+    android:height="9dp"
+    android:viewportWidth="9"
+    android:viewportHeight="9">
+  <group>
+    <clip-path
+        android:pathData="M0,0h9v9h-9z"/>
+    <path
+        android:pathData="M7.2,5.4H0V3.6H7.2V1.8H0V0H7.2H9V1.8V3.6V5.4V7.2V9H7.2H0V7.2H7.2V5.4Z"
+        android:fillColor="#000000"/>
+  </group>
+</vector>

--- a/composeApp/src/commonMain/composeResources/drawable/five_e_right.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/five_e_right.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="9dp"
+    android:height="9dp"
+    android:viewportWidth="9"
+    android:viewportHeight="9">
+  <group>
+    <clip-path
+        android:pathData="M0,0h9v9h-9z"/>
+    <path
+        android:pathData="M1.8,5.4H9V3.6H1.8V1.8H9V0H1.8H0V1.8V3.6V5.4V7.2V9H1.8H9V7.2H1.8V5.4Z"
+        android:fillColor="#000000"/>
+  </group>
+</vector>

--- a/composeApp/src/commonMain/composeResources/drawable/five_e_up.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/five_e_up.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="10dp"
+    android:height="9dp"
+    android:viewportWidth="10"
+    android:viewportHeight="9">
+  <group>
+    <clip-path
+        android:pathData="M0.536,0h9v9h-9z"/>
+    <path
+        android:pathData="M4.136,7.2V0H5.936V7.2H7.736V0H9.536V7.2V9H7.736H5.936H4.136H2.336H0.536V7.2V0H2.336V7.2H4.136Z"
+        android:fillColor="#000000"/>
+  </group>
+</vector>

--- a/composeApp/src/commonMain/composeResources/drawable/four_e_down.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/four_e_down.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="14dp"
+    android:height="14dp"
+    android:viewportWidth="14"
+    android:viewportHeight="14">
+  <group>
+    <clip-path
+        android:pathData="M0,0h14v14h-14z"/>
+    <path
+        android:pathData="M5.6,2.8V14H8.4V2.8H11.2V14H14V2.8V0H11.2H8.4H5.6H2.8H0V2.8V14H2.8V2.8H5.6Z"
+        android:fillColor="#000000"/>
+  </group>
+</vector>

--- a/composeApp/src/commonMain/composeResources/drawable/four_e_left.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/four_e_left.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="15dp"
+    android:height="14dp"
+    android:viewportWidth="15"
+    android:viewportHeight="14">
+  <group>
+    <clip-path
+        android:pathData="M0.611,0h14v14h-14z"/>
+    <path
+        android:pathData="M11.811,8.4H0.611V5.6H11.811V2.8H0.611V0H11.811H14.611V2.8V5.6V8.4V11.2V14H11.811H0.611V11.2H11.811V8.4Z"
+        android:fillColor="#000000"/>
+  </group>
+</vector>

--- a/composeApp/src/commonMain/composeResources/drawable/four_e_right.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/four_e_right.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="15dp"
+    android:height="14dp"
+    android:viewportWidth="15"
+    android:viewportHeight="14">
+  <group>
+    <clip-path
+        android:pathData="M0.722,0h14v14h-14z"/>
+    <path
+        android:pathData="M3.522,8.4H14.722V5.6H3.522V2.8H14.722V0H3.522H0.722V2.8V5.6V8.4V11.2V14H3.522H14.722V11.2H3.522V8.4Z"
+        android:fillColor="#000000"/>
+  </group>
+</vector>

--- a/composeApp/src/commonMain/composeResources/drawable/four_e_up.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/four_e_up.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="15dp"
+    android:height="14dp"
+    android:viewportWidth="15"
+    android:viewportHeight="14">
+  <group>
+    <clip-path
+        android:pathData="M0.833,0h14v14h-14z"/>
+    <path
+        android:pathData="M6.433,11.2V0H9.233V11.2H12.033V0H14.833V11.2V14H12.033H9.233H6.433H3.633H0.833V11.2V0H3.633V11.2H6.433Z"
+        android:fillColor="#000000"/>
+  </group>
+</vector>

--- a/composeApp/src/commonMain/composeResources/drawable/one_e_down.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/one_e_down.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="57dp"
+    android:height="57dp"
+    android:viewportWidth="57"
+    android:viewportHeight="57">
+  <group>
+    <clip-path
+        android:pathData="M0,0h57v57h-57z"/>
+    <path
+        android:pathData="M22.8,11.4V57H34.2V11.4H45.6V57H57V11.4V0H45.6H34.2H22.8H11.4H0V11.4V57H11.4V11.4H22.8Z"
+        android:fillColor="#000000"/>
+  </group>
+</vector>

--- a/composeApp/src/commonMain/composeResources/drawable/one_e_left.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/one_e_left.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="58dp"
+    android:height="57dp"
+    android:viewportWidth="58"
+    android:viewportHeight="57">
+  <group>
+    <clip-path
+        android:pathData="M0.774,0h57v57h-57z"/>
+    <path
+        android:pathData="M46.374,34.2H0.774V22.8H46.374V11.4H0.774V0H46.374H57.774V11.4V22.8V34.2V45.6V57H46.374H0.774V45.6H46.374V34.2Z"
+        android:fillColor="#000000"/>
+  </group>
+</vector>

--- a/composeApp/src/commonMain/composeResources/drawable/one_e_right.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/one_e_right.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="58dp"
+    android:height="57dp"
+    android:viewportWidth="58"
+    android:viewportHeight="57">
+  <group>
+    <clip-path
+        android:pathData="M0.726,0h57v57h-57z"/>
+    <path
+        android:pathData="M12.126,34.2H57.726V22.8H12.126V11.4H57.726V0H12.126H0.726V11.4V22.8V34.2V45.6V57H12.126H57.726V45.6H12.126V34.2Z"
+        android:fillColor="#000000"/>
+  </group>
+</vector>

--- a/composeApp/src/commonMain/composeResources/drawable/one_e_up.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/one_e_up.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="58dp"
+    android:height="57dp"
+    android:viewportWidth="58"
+    android:viewportHeight="57">
+  <group>
+    <clip-path
+        android:pathData="M0.678,0h57v57h-57z"/>
+    <path
+        android:pathData="M23.479,45.6V0H34.879V45.6H46.278V0H57.679V45.6V57H46.278H34.879H23.479H12.078H0.678V45.6V0H12.078V45.6H23.479Z"
+        android:fillColor="#000000"/>
+  </group>
+</vector>

--- a/composeApp/src/commonMain/composeResources/drawable/seven_e_down.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/seven_e_down.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="4dp"
+    android:height="4dp"
+    android:viewportWidth="4"
+    android:viewportHeight="4">
+  <group>
+    <clip-path
+        android:pathData="M0,0h4v4h-4z"/>
+    <path
+        android:pathData="M1.6,0.8V4H2.4V0.8H3.2V4H4V0.8V0H3.2H2.4H1.6H0.8H0V0.8V4H0.8V0.8H1.6Z"
+        android:fillColor="#000000"/>
+  </group>
+</vector>

--- a/composeApp/src/commonMain/composeResources/drawable/seven_e_left.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/seven_e_left.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="5dp"
+    android:height="4dp"
+    android:viewportWidth="5"
+    android:viewportHeight="4">
+  <group>
+    <clip-path
+        android:pathData="M0.4448,0h4v4h-4z"/>
+    <path
+        android:pathData="M3.6448,2.4H0.4448V1.6H3.6448V0.8H0.4448V0H3.6448H4.4448V0.8V1.6V2.4V3.2V4H3.6448H0.4448V3.2H3.6448V2.4Z"
+        android:fillColor="#000000"/>
+  </group>
+</vector>

--- a/composeApp/src/commonMain/composeResources/drawable/seven_e_right.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/seven_e_right.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="4dp"
+    android:height="4dp"
+    android:viewportWidth="4"
+    android:viewportHeight="4">
+  <group>
+    <clip-path
+        android:pathData="M0,0h4v4h-4z"/>
+    <path
+        android:pathData="M0.8,2.4H4V1.6H0.8V0.8H4V0H0.8H0V0.8V1.6V2.4V3.2V4H0.8H4V3.2H0.8V2.4Z"
+        android:fillColor="#000000"/>
+  </group>
+</vector>

--- a/composeApp/src/commonMain/composeResources/drawable/seven_e_up.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/seven_e_up.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="5dp"
+    android:height="4dp"
+    android:viewportWidth="5"
+    android:viewportHeight="4">
+  <group>
+    <clip-path
+        android:pathData="M0.3496,0h4v4h-4z"/>
+    <path
+        android:pathData="M1.9496,3.2V0H2.7496V3.2H3.5496V0H4.3496V3.2V4H3.5496H2.7496H1.9496H1.1496H0.3496V3.2V0H1.1496V3.2H1.9496Z"
+        android:fillColor="#000000"/>
+  </group>
+</vector>

--- a/composeApp/src/commonMain/composeResources/drawable/six_e_down.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/six_e_down.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="6dp"
+    android:height="6dp"
+    android:viewportWidth="6"
+    android:viewportHeight="6">
+  <group>
+    <clip-path
+        android:pathData="M0,0h6v6h-6z"/>
+    <path
+        android:pathData="M2.4,1.2V6H3.6V1.2H4.8V6H6V1.2V0H4.8H3.6H2.4H1.2H0V1.2V6H1.2V1.2H2.4Z"
+        android:fillColor="#000000"/>
+  </group>
+</vector>

--- a/composeApp/src/commonMain/composeResources/drawable/six_e_left.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/six_e_left.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="7dp"
+    android:height="6dp"
+    android:viewportWidth="7"
+    android:viewportHeight="6">
+  <group>
+    <clip-path
+        android:pathData="M0.667,0h6v6h-6z"/>
+    <path
+        android:pathData="M5.467,3.6H0.667V2.4H5.467V1.2H0.667V0H5.467H6.667V1.2V2.4V3.6V4.8V6H5.467H0.667V4.8H5.467V3.6Z"
+        android:fillColor="#000000"/>
+  </group>
+</vector>

--- a/composeApp/src/commonMain/composeResources/drawable/six_e_right.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/six_e_right.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="6dp"
+    android:height="6dp"
+    android:viewportWidth="6"
+    android:viewportHeight="6">
+  <group>
+    <clip-path
+        android:pathData="M0,0h6v6h-6z"/>
+    <path
+        android:pathData="M1.2,3.6H6V2.4H1.2V1.2H6V0H1.2H0V1.2V2.4V3.6V4.8V6H1.2H6V4.8H1.2V3.6Z"
+        android:fillColor="#000000"/>
+  </group>
+</vector>

--- a/composeApp/src/commonMain/composeResources/drawable/six_e_up.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/six_e_up.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="7dp"
+    android:height="6dp"
+    android:viewportWidth="7"
+    android:viewportHeight="6">
+  <group>
+    <clip-path
+        android:pathData="M0.0244,0h6v6h-6z"/>
+    <path
+        android:pathData="M2.4244,4.8V0H3.6244V4.8H4.8244V0H6.0244V4.8V6H4.8244H3.6244H2.4244H1.2244H0.0244V4.8V0H1.2244V4.8H2.4244Z"
+        android:fillColor="#000000"/>
+  </group>
+</vector>

--- a/composeApp/src/commonMain/composeResources/drawable/three_e_down.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/three_e_down.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="20"
+    android:viewportHeight="20">
+  <group>
+    <clip-path
+        android:pathData="M0,0h20v20h-20z"/>
+    <path
+        android:pathData="M8,4V20H12V4H16V20H20V4V0H16H12H8H4H0V4V20H4V4H8Z"
+        android:fillColor="#000000"/>
+  </group>
+</vector>

--- a/composeApp/src/commonMain/composeResources/drawable/three_e_left.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/three_e_left.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="21dp"
+    android:height="20dp"
+    android:viewportWidth="21"
+    android:viewportHeight="20">
+  <group>
+    <clip-path
+        android:pathData="M0.587,0h20v20h-20z"/>
+    <path
+        android:pathData="M16.587,12H0.587V8H16.587V4H0.587V0H16.587H20.587V4V8V12V16V20H16.587H0.587V16H16.587V12Z"
+        android:fillColor="#000000"/>
+  </group>
+</vector>

--- a/composeApp/src/commonMain/composeResources/drawable/three_e_right.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/three_e_right.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="21dp"
+    android:height="20dp"
+    android:viewportWidth="21"
+    android:viewportHeight="20">
+  <group>
+    <clip-path
+        android:pathData="M0.746,0h20v20h-20z"/>
+    <path
+        android:pathData="M4.746,12H20.746V8H4.746V4H20.746V0H4.746H0.746V4V8V12V16V20H4.746H20.746V16H4.746V12Z"
+        android:fillColor="#000000"/>
+  </group>
+</vector>

--- a/composeApp/src/commonMain/composeResources/drawable/three_e_up.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/three_e_up.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="21dp"
+    android:height="20dp"
+    android:viewportWidth="21"
+    android:viewportHeight="20">
+  <group>
+    <clip-path
+        android:pathData="M0.905,0h20v20h-20z"/>
+    <path
+        android:pathData="M8.905,16V0H12.905V16H16.905V0H20.905V16V20H16.905H12.905H8.905H4.905H0.905V16V0H4.905V16H8.905Z"
+        android:fillColor="#000000"/>
+  </group>
+</vector>

--- a/composeApp/src/commonMain/composeResources/drawable/two_e_down.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/two_e_down.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="29dp"
+    android:height="29dp"
+    android:viewportWidth="29"
+    android:viewportHeight="29">
+  <group>
+    <clip-path
+        android:pathData="M0,0h29v29h-29z"/>
+    <path
+        android:pathData="M11.6,5.8V29H17.4V5.8H23.2V29H29V5.8V0H23.2H17.4H11.6H5.8H0V5.8V29H5.8V5.8H11.6Z"
+        android:fillColor="#000000"/>
+  </group>
+</vector>

--- a/composeApp/src/commonMain/composeResources/drawable/two_e_left.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/two_e_left.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="30dp"
+    android:height="29dp"
+    android:viewportWidth="30"
+    android:viewportHeight="29">
+  <group>
+    <clip-path
+        android:pathData="M0.552,0h29v29h-29z"/>
+    <path
+        android:pathData="M23.752,17.4H0.552V11.6H23.752V5.8H0.552V0H23.752H29.552V5.8V11.6V17.4V23.2V29H23.752H0.552V23.2H23.752V17.4Z"
+        android:fillColor="#000000"/>
+  </group>
+</vector>

--- a/composeApp/src/commonMain/composeResources/drawable/two_e_right.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/two_e_right.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="30dp"
+    android:height="29dp"
+    android:viewportWidth="30"
+    android:viewportHeight="29">
+  <group>
+    <clip-path
+        android:pathData="M0.282,0h29v29h-29z"/>
+    <path
+        android:pathData="M6.082,17.4H29.282V11.6H6.082V5.8H29.282V0H6.082H0.282V5.8V11.6V17.4V23.2V29H6.082H29.282V23.2H6.082V17.4Z"
+        android:fillColor="#000000"/>
+  </group>
+</vector>

--- a/composeApp/src/commonMain/composeResources/drawable/two_e_up.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/two_e_up.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="30dp"
+    android:height="29dp"
+    android:viewportWidth="30"
+    android:viewportHeight="29">
+  <group>
+    <clip-path
+        android:pathData="M0.012,0h29v29h-29z"/>
+    <path
+        android:pathData="M11.612,23.2V0H17.412V23.2H23.212V0H29.012V23.2V29H23.212H17.412H11.612H5.812H0.012V23.2V0H5.812V23.2H11.612Z"
+        android:fillColor="#000000"/>
+  </group>
+</vector>

--- a/composeApp/src/commonMain/kotlin/com/europa/sightup/data/remote/api/SightUpApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/europa/sightup/data/remote/api/SightUpApiService.kt
@@ -3,15 +3,19 @@ package com.europa.sightup.data.remote.api
 import com.europa.sightup.data.remote.request.ProfileRequest
 import com.europa.sightup.data.remote.request.auth.LoginRequest
 import com.europa.sightup.data.remote.request.auth.LoginWithProviderRequest
+import com.europa.sightup.data.remote.request.visionHistory.VisionHistoryRequest
 import com.europa.sightup.data.remote.response.ExerciseResponse
 import com.europa.sightup.data.remote.response.ProfileResponse
 import com.europa.sightup.data.remote.response.TaskResponse
 import com.europa.sightup.data.remote.response.TestResponse
 import com.europa.sightup.data.remote.response.auth.LoginEmailResponse
 import com.europa.sightup.data.remote.response.auth.LoginResponse
+import com.europa.sightup.data.remote.response.visionHistory.UserHistoryResponse
+import com.europa.sightup.data.remote.response.visionHistory.VisionHistoryResponse
 import de.jensklingenberg.ktorfit.http.Body
 import de.jensklingenberg.ktorfit.http.GET
 import de.jensklingenberg.ktorfit.http.POST
+import de.jensklingenberg.ktorfit.http.Path
 import de.jensklingenberg.ktorfit.http.Query
 
 interface SightUpApiService {
@@ -35,6 +39,16 @@ interface SightUpApiService {
     suspend fun setupProfile(
         @Body request: ProfileRequest,
     ): ProfileResponse
+
+    @POST("api/user/visionHistory")
+    suspend fun saveTestResult(
+        @Body request: VisionHistoryRequest,
+    ) : VisionHistoryResponse
+
+    @GET("api/user/visionHistory/{user}")
+    suspend fun getUserTests(
+        @Path("user") user: String
+    ): UserHistoryResponse
 
     @GET("api/tasks/allTasks")
     suspend fun getTasks(): List<TaskResponse>

--- a/composeApp/src/commonMain/kotlin/com/europa/sightup/data/remote/request/visionHistory/ResultRequest.kt
+++ b/composeApp/src/commonMain/kotlin/com/europa/sightup/data/remote/request/visionHistory/ResultRequest.kt
@@ -1,0 +1,10 @@
+package com.europa.sightup.data.remote.request.visionHistory
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ResultRequest(
+    @SerialName("left") val left: String,
+    @SerialName("right") val right: String
+)

--- a/composeApp/src/commonMain/kotlin/com/europa/sightup/data/remote/request/visionHistory/VisionHistoryRequest.kt
+++ b/composeApp/src/commonMain/kotlin/com/europa/sightup/data/remote/request/visionHistory/VisionHistoryRequest.kt
@@ -1,0 +1,14 @@
+package com.europa.sightup.data.remote.request.visionHistory
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class VisionHistoryRequest(
+    @SerialName("userId") val userId: String,
+    @SerialName("userEmail") val userEmail: String,
+    @SerialName("appTest") val appTest: Boolean,
+    @SerialName("testId") val testId: String,
+    @SerialName("testTitle") val testTitle: String,
+    @SerialName("result") val result: ResultRequest
+)

--- a/composeApp/src/commonMain/kotlin/com/europa/sightup/data/remote/response/visionHistory/VisionHistoryResponse.kt
+++ b/composeApp/src/commonMain/kotlin/com/europa/sightup/data/remote/response/visionHistory/VisionHistoryResponse.kt
@@ -1,0 +1,33 @@
+package com.europa.sightup.data.remote.response.visionHistory
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class VisionHistoryResponse(
+    @SerialName("message") val message: String,
+    @SerialName("userHistory") val userHistory: UserHistoryResponse,
+)
+
+@Serializable
+data class UserHistoryResponse(
+    @SerialName("userId") val userId: String,
+    @SerialName("userEmail") val userEmail: String,
+    @SerialName("appTest") val appTest: Boolean,
+    @SerialName("tests") val tests: List<TestResponse>,
+    @SerialName("_id") val id: String,
+)
+
+@Serializable
+data class TestResponse(
+    @SerialName("testId") val testId: String,
+    @SerialName("testTitle") val testTitle: String,
+    @SerialName("date") val date: String,
+    @SerialName("result") val result: ResultResponse,
+)
+
+@Serializable
+data class ResultResponse(
+    @SerialName("left") val left: String,
+    @SerialName("right") val right: String,
+)

--- a/composeApp/src/commonMain/kotlin/com/europa/sightup/di/KoinModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/europa/sightup/di/KoinModule.kt
@@ -12,6 +12,7 @@ import com.europa.sightup.presentation.MainViewModel
 import com.europa.sightup.presentation.screens.exercise.ExerciseViewModel
 import com.europa.sightup.presentation.screens.onboarding.LoginViewModel
 import com.europa.sightup.presentation.screens.test.active.ActiveTestViewModel
+import com.europa.sightup.presentation.screens.test.result.TestResultViewModel
 import com.europa.sightup.presentation.screens.test.root.TestViewModel
 import com.europa.sightup.presentation.screens.test.tutorial.TutorialTestViewModel
 import com.europa.sightup.utils.ANDROID
@@ -50,7 +51,8 @@ val commonModule = module {
     viewModel { TestViewModel(repository = get()) }
     viewModel { ExerciseViewModel(repository = get()) }
     viewModel { TutorialTestViewModel() }
-    viewModel { ActiveTestViewModel(repository = get()) }
+    viewModel { ActiveTestViewModel() }
+    viewModel { TestResultViewModel( repository = get()) }
 }
 
 fun initializeKoin(

--- a/composeApp/src/commonMain/kotlin/com/europa/sightup/presentation/navigation/Routes.kt
+++ b/composeApp/src/commonMain/kotlin/com/europa/sightup/presentation/navigation/Routes.kt
@@ -107,6 +107,15 @@ sealed interface TestScreens {
             return TestActive::class.simpleName.toString()
         }
     }
+
+    @Serializable
+    data class TestResult(
+        val appTest: Boolean,
+        val testId: String,
+        val testTitle: String,
+        val left: String,
+        val right: String,
+    ) : TestScreens
 }
 
 // Prescriptions Routes

--- a/composeApp/src/commonMain/kotlin/com/europa/sightup/presentation/navigation/TestNavGraph.kt
+++ b/composeApp/src/commonMain/kotlin/com/europa/sightup/presentation/navigation/TestNavGraph.kt
@@ -4,6 +4,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
+import androidx.navigation.toRoute
 import com.europa.sightup.data.remote.response.TestResponse
 import com.europa.sightup.presentation.designsystem.components.TestModeEnum
 import com.europa.sightup.presentation.navigation.TestScreens.TestActive
@@ -11,8 +12,10 @@ import com.europa.sightup.presentation.navigation.TestScreens.TestIndividual
 import com.europa.sightup.presentation.navigation.TestScreens.TestInit
 import com.europa.sightup.presentation.navigation.TestScreens.TestRoot
 import com.europa.sightup.presentation.navigation.TestScreens.TestTutorial
+import com.europa.sightup.presentation.navigation.TestScreens.TestResult
 import com.europa.sightup.presentation.screens.test.IndividualTestScreen
 import com.europa.sightup.presentation.screens.test.active.ActiveTestScreen
+import com.europa.sightup.presentation.screens.test.result.TestResultScreen
 import com.europa.sightup.presentation.screens.test.root.TestScreenWithState
 import com.europa.sightup.presentation.screens.test.tutorial.TutorialTestScreen
 import com.europa.sightup.utils.getObjectFromArgs
@@ -53,5 +56,19 @@ fun NavGraphBuilder.testNavGraph(navController: NavHostController) {
                 )
             }
         }
+
+
+        composable<TestResult>{
+            val testResult = it.toRoute<TestResult>()
+
+            TestResultScreen(
+                appTest = testResult.appTest,
+                testId = testResult.testId,
+                testTitle = testResult.testTitle,
+                left = testResult.left,
+                right = testResult.right
+            )
+        }
+
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/europa/sightup/presentation/screens/test/active/AstigmatismChart.kt
+++ b/composeApp/src/commonMain/kotlin/com/europa/sightup/presentation/screens/test/active/AstigmatismChart.kt
@@ -1,0 +1,22 @@
+package com.europa.sightup.presentation.screens.test.active
+
+enum class AstigmatismChart(val angle: Int) {
+    DIRECTION_1(15),
+    DIRECTION_2(30),
+    DIRECTION_3(45),
+    DIRECTION_4(60),
+    DIRECTION_5(75),
+    DIRECTION_6(90),
+    DIRECTION_7(105),
+    DIRECTION_8(120),
+    DIRECTION_9(135),
+    DIRECTION_10(150),
+    DIRECTION_11(165),
+    DIRECTION_12(180);
+
+    companion object {
+        fun getAngleForDirection(direction: Int): String? {
+            return values().firstOrNull { it.name == "DIRECTION_$direction" }?.angle.toString()
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/europa/sightup/presentation/screens/test/active/EChart.kt
+++ b/composeApp/src/commonMain/kotlin/com/europa/sightup/presentation/screens/test/active/EChart.kt
@@ -2,58 +2,94 @@ package com.europa.sightup.presentation.screens.test.active
 
 import org.jetbrains.compose.resources.DrawableResource
 import sightupkmpapp.composeapp.generated.resources.Res
-import sightupkmpapp.composeapp.generated.resources.e_down
-import sightupkmpapp.composeapp.generated.resources.e_left
-import sightupkmpapp.composeapp.generated.resources.e_right
-import sightupkmpapp.composeapp.generated.resources.e_up
+import sightupkmpapp.composeapp.generated.resources.eight_e_down
+import sightupkmpapp.composeapp.generated.resources.eight_e_left
+import sightupkmpapp.composeapp.generated.resources.eight_e_right
+import sightupkmpapp.composeapp.generated.resources.eight_e_up
+import sightupkmpapp.composeapp.generated.resources.five_e_down
+import sightupkmpapp.composeapp.generated.resources.five_e_left
+import sightupkmpapp.composeapp.generated.resources.five_e_right
+import sightupkmpapp.composeapp.generated.resources.five_e_up
+import sightupkmpapp.composeapp.generated.resources.four_e_down
+import sightupkmpapp.composeapp.generated.resources.four_e_left
+import sightupkmpapp.composeapp.generated.resources.four_e_right
+import sightupkmpapp.composeapp.generated.resources.four_e_up
+import sightupkmpapp.composeapp.generated.resources.one_e_down
+import sightupkmpapp.composeapp.generated.resources.one_e_left
+import sightupkmpapp.composeapp.generated.resources.one_e_right
+import sightupkmpapp.composeapp.generated.resources.one_e_up
+import sightupkmpapp.composeapp.generated.resources.seven_e_down
+import sightupkmpapp.composeapp.generated.resources.seven_e_left
+import sightupkmpapp.composeapp.generated.resources.seven_e_right
+import sightupkmpapp.composeapp.generated.resources.seven_e_up
+import sightupkmpapp.composeapp.generated.resources.six_e_down
+import sightupkmpapp.composeapp.generated.resources.six_e_left
+import sightupkmpapp.composeapp.generated.resources.six_e_right
+import sightupkmpapp.composeapp.generated.resources.six_e_up
+import sightupkmpapp.composeapp.generated.resources.three_e_down
+import sightupkmpapp.composeapp.generated.resources.three_e_left
+import sightupkmpapp.composeapp.generated.resources.three_e_right
+import sightupkmpapp.composeapp.generated.resources.three_e_up
+import sightupkmpapp.composeapp.generated.resources.two_e_down
+import sightupkmpapp.composeapp.generated.resources.two_e_left
+import sightupkmpapp.composeapp.generated.resources.two_e_right
+import sightupkmpapp.composeapp.generated.resources.two_e_up
 
-enum class EChart(val resourceId: DrawableResource) {
-    UP(Res.drawable.e_up),
-    DOWN(Res.drawable.e_down),
-    LEFT(Res.drawable.e_left),
-    RIGHT(Res.drawable.e_right);
+enum class EChart {
+    UP,
+    DOWN,
+    LEFT,
+    RIGHT;
 
     companion object {
         private val chartRows = hashMapOf(
-            Pair(
-                1, hashMapOf(
-                    UP to Res.drawable.e_up,
-                    DOWN to Res.drawable.e_down,
-                    LEFT to Res.drawable.e_left,
-                    RIGHT to Res.drawable.e_right
-                )
+            1 to listOf(
+                EChartIcon(UP, Res.drawable.one_e_up),
+                EChartIcon(DOWN, Res.drawable.one_e_down),
+                EChartIcon(LEFT, Res.drawable.one_e_left),
+                EChartIcon(RIGHT, Res.drawable.one_e_right)
             ),
-            Pair(
-                2, hashMapOf(
-                    UP to Res.drawable.e_up,
-                    DOWN to Res.drawable.e_down,
-                    LEFT to Res.drawable.e_left,
-                    RIGHT to Res.drawable.e_right
-                )
+            2 to listOf(
+                EChartIcon(UP, Res.drawable.two_e_up),
+                EChartIcon(DOWN, Res.drawable.two_e_down),
+                EChartIcon(LEFT, Res.drawable.two_e_left),
+                EChartIcon(RIGHT, Res.drawable.two_e_right)
             ),
-            Pair(
-                3, hashMapOf(
-                    UP to Res.drawable.e_up,
-                    DOWN to Res.drawable.e_down,
-                    LEFT to Res.drawable.e_left,
-                    RIGHT to Res.drawable.e_right
-                )
+            3 to listOf(
+                EChartIcon(UP, Res.drawable.three_e_up),
+                EChartIcon(DOWN, Res.drawable.three_e_down),
+                EChartIcon(LEFT, Res.drawable.three_e_left),
+                EChartIcon(RIGHT, Res.drawable.three_e_right)
             ),
-            Pair(
-                4, hashMapOf(
-                    UP to Res.drawable.e_up,
-                    DOWN to Res.drawable.e_down,
-                    LEFT to Res.drawable.e_left,
-                    RIGHT to Res.drawable.e_right
-                )
+            4 to listOf(
+                EChartIcon(UP, Res.drawable.four_e_up),
+                EChartIcon(DOWN, Res.drawable.four_e_down),
+                EChartIcon(LEFT, Res.drawable.four_e_left),
+                EChartIcon(RIGHT, Res.drawable.four_e_right)
             ),
-            Pair(
-                5, hashMapOf(
-                    UP to Res.drawable.e_up,
-                    DOWN to Res.drawable.e_down,
-                    LEFT to Res.drawable.e_left,
-                    RIGHT to Res.drawable.e_right
-                )
+            5 to listOf(
+                EChartIcon(UP, Res.drawable.five_e_up),
+                EChartIcon(DOWN, Res.drawable.five_e_down),
+                EChartIcon(LEFT, Res.drawable.five_e_left),
+                EChartIcon(RIGHT, Res.drawable.five_e_right)
+            ),
+            6 to listOf(
+                EChartIcon(UP, Res.drawable.six_e_up),
+                EChartIcon(DOWN, Res.drawable.six_e_down),
+                EChartIcon(LEFT, Res.drawable.six_e_left),
+                EChartIcon(RIGHT, Res.drawable.six_e_right)
+            ),
+            7 to listOf(
+                EChartIcon(UP, Res.drawable.seven_e_up),
+                EChartIcon(DOWN, Res.drawable.seven_e_down),
+                EChartIcon(LEFT, Res.drawable.seven_e_left),
+                EChartIcon(RIGHT, Res.drawable.seven_e_right)
+            ),
+            8 to listOf(
+                EChartIcon(UP, Res.drawable.eight_e_up),
+                EChartIcon(DOWN, Res.drawable.eight_e_down),
+                EChartIcon(LEFT, Res.drawable.eight_e_left),
+                EChartIcon(RIGHT, Res.drawable.eight_e_right)
             )
         )
 
@@ -62,19 +98,20 @@ enum class EChart(val resourceId: DrawableResource) {
             2 to "20/100",
             3 to "20/70",
             4 to "20/50",
-            5 to "20/40"
+            5 to "20/40",
+            6 to "20/30",
+            7 to "20/20",
+            8 to "20/10"
         )
 
-        fun fromString(value: String): EChart? {
-            return EChart.entries.firstOrNull {
-                it.name.contains(value, ignoreCase = true)
-            }
-        }
+        fun getRandomIcon(row: Int, lastDirection: EChart? = null): EChartIcon? {
+            val directions = chartRows[row]?.toMutableList() ?: return null
 
-        fun getRandomIcon(row: Int): DrawableResource? {
-            val directions = chartRows[row]?.keys?.toList()
-            val randomDirection = directions?.random()
-            return randomDirection?.let { chartRows[row]?.get(it) }
+            // Remove from the list the last direction
+            lastDirection?.let {
+                directions.removeAll { icon -> icon.direction == lastDirection }
+            }
+            return directions.randomOrNull()
         }
 
         fun getScoreForRow(row: Int): String? {
@@ -82,3 +119,5 @@ enum class EChart(val resourceId: DrawableResource) {
         }
     }
 }
+
+data class EChartIcon(val direction: EChart, val resourceId: DrawableResource)

--- a/composeApp/src/commonMain/kotlin/com/europa/sightup/presentation/screens/test/result/TestResultScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/europa/sightup/presentation/screens/test/result/TestResultScreen.kt
@@ -1,0 +1,130 @@
+package com.europa.sightup.presentation.screens.test.result
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.europa.sightup.data.remote.response.visionHistory.UserHistoryResponse
+import com.europa.sightup.utils.UIState
+import org.koin.compose.viewmodel.koinViewModel
+
+@Composable
+fun TestResultScreen(
+    appTest: Boolean = true,
+    testId: String = "",
+    testTitle: String = "",
+    left: String = "",
+    right: String = "",
+) {
+    val viewModel = koinViewModel<TestResultViewModel>()
+
+    val testResultState by viewModel.newTestResult.collectAsState()
+    val visionHistoryState by viewModel.visionHistory.collectAsState()
+
+    // TODO DELETE THIS AFTER
+    Column(
+        modifier = Modifier.fillMaxSize().padding(16.dp).verticalScroll(rememberScrollState()),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text("You're in the test result screen")
+        Text("App Test: $appTest")
+        Text("Test ID: $testId")
+        Text("Test Title: $testTitle")
+        Text("Left Eye Result: $left")
+        Text("Right Eye Result: $right")
+
+        Button(onClick = {
+            viewModel.saveVisionTest(
+                appTest = appTest,
+                testId = testId,
+                testTitle = testTitle,
+                left = left,
+                right = right
+            )
+        }) {
+            Text("Save to DB")
+        }
+
+        when (testResultState) {
+            is UIState.Loading -> {
+                Text("Saving test result...")
+            }
+
+            is UIState.Success -> {
+                Text("Test saved successfully!")
+                GetVisionHistory(viewModel, visionHistoryState)
+            }
+
+            is UIState.Error -> {
+                Text("Error saving test: ${(testResultState as UIState.Error).message}")
+            }
+
+            else -> {
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+        }
+    }
+}
+
+@Composable
+fun GetVisionHistory(viewModel: TestResultViewModel, visionHistoryState: UIState<List<UserHistoryResponse>>) {
+    Column(
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+        horizontalAlignment = Alignment.Start,
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Button(onClick = { viewModel.getVisionHistory() }) {
+            Text("Get Vision History")
+        }
+
+        when (visionHistoryState) {
+            is UIState.Loading -> {
+                Text("Loading vision history...")
+            }
+
+            is UIState.Success -> {
+                val userHistoryList = (visionHistoryState as UIState.Success<List<UserHistoryResponse>>).data
+
+                if (userHistoryList.isEmpty()) {
+                    Text("No test history available.")
+                } else {
+                    userHistoryList.forEach { userHistory ->
+                        Text("User ID: ${userHistory.userId}")
+                        Text("User Email: ${userHistory.userEmail}")
+
+                        userHistory.tests.forEach { test ->
+                            Spacer(modifier = Modifier.padding(vertical = 8.dp))
+                            Text("Test ID: ${test.testId}")
+                            Text("Title: ${test.testTitle}")
+                            Text("Date: ${test.date}")
+                            Text("Left Eye Result: ${test.result.left}")
+                            Text("Right Eye Result: ${test.result.right}")
+                        }
+                    }
+                }
+            }
+
+            is UIState.Error -> {
+                Text("Error loading history: ${(visionHistoryState as UIState.Error).message}")
+            }
+
+            else -> {
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/europa/sightup/presentation/screens/test/result/TestResultViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/europa/sightup/presentation/screens/test/result/TestResultViewModel.kt
@@ -1,0 +1,80 @@
+package com.europa.sightup.presentation.screens.test.result
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.europa.sightup.data.remote.request.visionHistory.ResultRequest
+import com.europa.sightup.data.remote.response.visionHistory.UserHistoryResponse
+import com.europa.sightup.data.remote.response.visionHistory.VisionHistoryResponse
+import com.europa.sightup.data.repository.SightUpRepository
+import com.europa.sightup.utils.UIState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.update
+
+class TestResultViewModel(private val repository: SightUpRepository) : ViewModel() {
+
+    private val _newTestResult = MutableStateFlow<UIState<VisionHistoryResponse>>(UIState.InitialState())
+    val newTestResult: StateFlow<UIState<VisionHistoryResponse>> = _newTestResult.asStateFlow()
+
+    fun saveVisionTest(
+        appTest: Boolean = true,
+        testId: String = "",
+        testTitle: String = "",
+        left: String = "",
+        right: String = "",
+    ) {
+        repository.postUserTestsResult(
+            appTest = appTest,
+            testId = testId,
+            testTitle = testTitle,
+            result = ResultRequest(
+                left = left,
+                right = right
+            )
+        )
+            .onStart {
+                println("onStart")
+                _newTestResult.update { UIState.Loading() }
+            }
+            .onEach { response: VisionHistoryResponse ->
+                println("onEach")
+                _newTestResult.update { UIState.Success(response) }
+            }
+            .catch { error ->
+                println("Error")
+                _newTestResult.update { UIState.Error(error.message ?: "Unknown error") }
+            }
+            .launchIn(viewModelScope)
+    }
+
+    private val _visionHistory = MutableStateFlow<UIState<List<UserHistoryResponse>>>(UIState.InitialState())
+    val visionHistory: StateFlow<UIState<List<UserHistoryResponse>>> = _visionHistory.asStateFlow()
+
+    fun getVisionHistory() {
+        repository.getUserVisionHistory()
+            .onStart {
+                println("onStart")
+                _visionHistory.update { UIState.Loading() }
+            }
+            .onEach { response: UserHistoryResponse ->
+                println("onEach")
+                _visionHistory.update { current ->
+                    // Actualiza la lista actual agregando el nuevo elemento
+                    val updatedList = (current as? UIState.Success)?.data.orEmpty() + response
+                    UIState.Success(updatedList)
+                }
+            }
+            .catch { error ->
+                println("Error")
+                _visionHistory.update { UIState.Error(error.message ?: "Unknown error") }
+            }
+            .launchIn(viewModelScope)
+    }
+}
+
+

--- a/composeApp/src/commonMain/kotlin/com/europa/sightup/presentation/screens/test/root/TestViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/europa/sightup/presentation/screens/test/root/TestViewModel.kt
@@ -26,12 +26,7 @@ class TestViewModel(private val repository: SightUpRepository) : ViewModel() {
 
 
     fun getTests() {
-        flow {
-            val test = withContext(Dispatchers.IO) {
-                repository.getTests()
-            }
-            emit(test)
-        }
+        repository.getTests()
             .onStart {
                 println("onStart")
                 _tests.update { UIState.Loading() }


### PR DESCRIPTION
## Description

*Include a detailed summary of the changes and which issue is fixed in this pull request.
Explain the problem this PR solves or the functionality it implements.*

TASK: #EC-290
- Add enpoints to the api service
- Fix ActiveScreenViewModel to effectively store the results of the test, and handle both tests 
-Refactor enum EChart to use the correct icons and fix random function

## Type of change

*Mark with an `x` the types of changes that apply to your PR.*

- [ ] Bugfix or Hotfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected or affects the API)
- [x] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] New documentation or documentation update
- [ ] Other (please specify below)

## Screenshots (if applicable)
<img width="359" alt="Screenshot 2024-11-03 at 10 26 41 PM" src="https://github.com/user-attachments/assets/ee0deff9-a23b-4c57-8a4f-383879fd9038">
<img width="353" alt="Screenshot 2024-11-03 at 10 28 31 PM" src="https://github.com/user-attachments/assets/24dad5bb-776f-484d-90da-0ec522ea2038">

*If your changes include visual updates, add screenshots to show before and after.*


## Checklist:

*Mark with an `x` the items that have been completed.*

- [x] I have merged/rebased the main branch into my feature branch before submitting the PR.
- [x] I have checked my code and corrected any misspellings
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Both platforms are working (Android and IOS)


## Additional Information

*If there is anything else you would like to highlight, add additional context, or provide any other relevant information, do so here.*

